### PR TITLE
pypi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#pypi
+.pypitoken
+
 __pycache__/
 *.py[cod]
 .env/

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     entry_points={
         "console_scripts": ['gh_label_maker=gh_label_maker.cli:run']
     },
-    classifiers=["Programing Language :: Python :: 3.10"]
+    classifiers=["Programming Language :: Python :: 3.10"]
 )


### PR DESCRIPTION
- moved source code and schemas
- created an installable package
- ignore typical python packaging stuff used template: https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
- import from package instead of filesystem relative
- added hint pip install hint for devs
- Moved cli main body to a function
- added entrypoint to the package for using the package as cli tool
- fixed typo, pypi does not except invalid classifers
- dont publish pypi token
