### PR TITLE
pypi release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#pypi
+.pypitoken
+
 __pycache__/
 *.py[cod]
 .env/

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     entry_points={
         "console_scripts": ['gh_label_maker=gh_label_maker.cli:run']
     },
-    classifiers=["Programing Language :: Python :: 3.10"]
+    classifiers=["Programming Language :: Python :: 3.10"]
 )


### PR DESCRIPTION
This have been published at [pypi/gh-label-maker](https://pypi.org/project/gh-label-maker/0.0.1/#history)
- fixed typo, pypi does not except invalid classifers
- dont publish pypi token
