### PR TITLE
New pypi version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="gh_label_maker",
-    version="0.0.1",
+    version="0.0.2",
     description="CLI tool for managing github labels",
     packages=["gh_label_maker"],
     install_requires=["PyGithub==1.56"],


### PR DESCRIPTION
I want to push the bugg fix of #7 to pypi
This requires a new version name in the setup.py